### PR TITLE
Add paid invoice for fully paid orders

### DIFF
--- a/includes/Admin.php
+++ b/includes/Admin.php
@@ -229,8 +229,11 @@ class Admin {
 		$listing_actions = array();
 		$documents       = WPO_WCPDF()->documents->get_documents( 'enabled', 'any' );
 
-		foreach ( $documents as $document ) {
-			$document_title = $document->get_title();
+               foreach ( $documents as $document ) {
+                       if ( 'paid-invoice' === $document->get_type() && ! wcpdf_order_fully_paid( $order ) ) {
+                               continue;
+                       }
+                       $document_title = $document->get_title();
 			$document_type  = $document->get_type();
 			$icon           = ! empty( $document->icon ) ? $document->icon : WPO_WCPDF()->plugin_url() . '/assets/images/generic_document.svg';
 

--- a/includes/Documents.php
+++ b/includes/Documents.php
@@ -43,9 +43,10 @@ class Documents {
 	 * Init document classes.
 	 */
 	public function init() {
-		// Load Invoice & Packing Slip
-		$this->documents['\WPO\IPS\Documents\Invoice']     = new \WPO\IPS\Documents\Invoice();
-		$this->documents['\WPO\IPS\Documents\PackingSlip'] = new \WPO\IPS\Documents\PackingSlip();
+               // Load Invoice, Paid Invoice & Packing Slip
+               $this->documents['\WPO\IPS\Documents\Invoice']      = new \WPO\IPS\Documents\Invoice();
+               $this->documents['\WPO\IPS\Documents\PaidInvoice'] = new \WPO\IPS\Documents\PaidInvoice();
+               $this->documents['\WPO\IPS\Documents\PackingSlip']  = new \WPO\IPS\Documents\PackingSlip();
 
 		// Allow plugins to add their own documents
 		$this->documents = apply_filters( 'wpo_wcpdf_document_classes', $this->documents );

--- a/includes/Documents/PaidInvoice.php
+++ b/includes/Documents/PaidInvoice.php
@@ -1,0 +1,48 @@
+<?php
+namespace WPO\IPS\Documents;
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit; // Exit if accessed directly
+}
+
+if ( ! class_exists( '\\WPO\\IPS\\Documents\\PaidInvoice' ) ) :
+
+/**
+ * Invoice document shown when all payments are completed.
+ */
+class PaidInvoice extends Invoice {
+
+    /**
+     * Init/load the order object.
+     *
+     * @param int|object|\WC_Order $order Order to init.
+     */
+    public function __construct( $order = 0 ) {
+        $this->type = 'paid-invoice';
+        $this->title = __( 'Invoice', 'woocommerce-pdf-invoices-packing-slips' );
+        $this->icon  = WPO_WCPDF()->plugin_url() . '/assets/images/invoice.svg';
+
+        parent::__construct( $order );
+
+        // only pdf output format
+        $this->output_formats = apply_filters( 'wpo_wcpdf_document_output_formats', array( 'pdf' ), $this );
+    }
+
+    /**
+     * Hide due date for this document.
+     */
+    public function show_due_date(): bool {
+        return false;
+    }
+
+    /**
+     * Add confirmation message to document notes.
+     */
+    public function get_document_notes() {
+        $notes = parent::get_document_notes();
+        $notes .= '<p>' . __( 'All Payments Completed', 'woocommerce-pdf-invoices-packing-slips' ) . '</p>';
+        return $notes;
+    }
+}
+
+endif; // class_exists

--- a/includes/Frontend.php
+++ b/includes/Frontend.php
@@ -64,12 +64,21 @@ class Frontend {
 			}
 
 			// Check if invoice has been created already or if status allows download (filter your own array of allowed statuses)
-			if ( $invoice_allowed || in_array( $order->get_status(), apply_filters( 'wpo_wcpdf_myaccount_allowed_order_statuses', array() ) ) ) {
-				$actions['invoice'] = array(
-					'url'  => WPO_WCPDF()->endpoint->get_document_link( $order, 'invoice', array( 'my-account' => 'true' ) ),
-					'name' => apply_filters( 'wpo_wcpdf_myaccount_button_text', $invoice->get_title(), $invoice )
-				);
-			}
+                       if ( $invoice_allowed || in_array( $order->get_status(), apply_filters( 'wpo_wcpdf_myaccount_allowed_order_statuses', array() ) ) ) {
+                               $actions['invoice'] = array(
+                                       'url'  => WPO_WCPDF()->endpoint->get_document_link( $order, 'invoice', array( 'my-account' => 'true' ) ),
+                                       'name' => apply_filters( 'wpo_wcpdf_myaccount_button_text', $invoice->get_title(), $invoice )
+                               );
+                               if ( wcpdf_order_fully_paid( $order ) ) {
+                                       $paid = wcpdf_get_paid_invoice( $order );
+                                       if ( $paid && $paid->is_enabled() ) {
+                                               $actions['paid-invoice'] = array(
+                                                       'url'  => WPO_WCPDF()->endpoint->get_document_link( $order, 'paid-invoice', array( 'my-account' => 'true' ) ),
+                                                       'name' => __( 'PDF Invoice All Payments Completed', 'woocommerce-pdf-invoices-packing-slips' ),
+                                               );
+                                       }
+                               }
+                       }
 		}
 
 		return apply_filters( 'wpo_wcpdf_myaccount_actions', $actions, $order );

--- a/templates/Simple/paid-invoice.php
+++ b/templates/Simple/paid-invoice.php
@@ -1,0 +1,185 @@
+<?php if ( ! defined( 'ABSPATH' ) ) exit; // Exit if accessed directly ?>
+
+<?php do_action( 'wpo_wcpdf_before_document', $this->get_type(), $this->order ); ?>
+
+<table class="head container">
+	<tr>
+		<td class="header">
+			<?php if ( $this->has_header_logo() ) : ?>
+				<?php do_action( 'wpo_wcpdf_before_shop_logo', $this->get_type(), $this->order ); ?>
+				<?php $this->header_logo(); ?>
+				<?php do_action( 'wpo_wcpdf_after_shop_logo', $this->get_type(), $this->order ); ?>
+			<?php else : ?>
+				<?php $this->title(); ?>
+			<?php endif; ?>
+		</td>
+		<td class="shop-info">
+			<?php do_action( 'wpo_wcpdf_before_shop_name', $this->get_type(), $this->order ); ?>
+			<div class="shop-name"><h3><?php $this->shop_name(); ?></h3></div>
+			<?php do_action( 'wpo_wcpdf_after_shop_name', $this->get_type(), $this->order ); ?>
+			<?php do_action( 'wpo_wcpdf_before_shop_address', $this->get_type(), $this->order ); ?>
+			<div class="shop-address"><?php $this->shop_address(); ?></div>
+			<?php do_action( 'wpo_wcpdf_after_shop_address', $this->get_type(), $this->order ); ?>
+		</td>
+	</tr>
+</table>
+
+<?php do_action( 'wpo_wcpdf_before_document_label', $this->get_type(), $this->order ); ?>
+
+<?php if ( $this->has_header_logo() ) : ?>
+	<h1 class="document-type-label"><?php $this->title(); ?></h1>
+<?php endif; ?>
+
+<?php do_action( 'wpo_wcpdf_after_document_label', $this->get_type(), $this->order ); ?>
+
+<table class="order-data-addresses">
+	<tr>
+		<td class="address billing-address">
+			<?php do_action( 'wpo_wcpdf_before_billing_address', $this->get_type(), $this->order ); ?>
+			<p><?php $this->billing_address(); ?></p>
+			<?php do_action( 'wpo_wcpdf_after_billing_address', $this->get_type(), $this->order ); ?>
+			<?php if ( isset( $this->settings['display_email'] ) ) : ?>
+				<div class="billing-email"><?php $this->billing_email(); ?></div>
+			<?php endif; ?>
+			<?php if ( isset( $this->settings['display_phone'] ) ) : ?>
+				<div class="billing-phone"><?php $this->billing_phone(); ?></div>
+			<?php endif; ?>
+		</td>
+		<td class="address shipping-address">
+			<?php if ( $this->show_shipping_address() ) : ?>
+				<h3><?php $this->shipping_address_title(); ?></h3>
+				<?php do_action( 'wpo_wcpdf_before_shipping_address', $this->get_type(), $this->order ); ?>
+				<p><?php $this->shipping_address(); ?></p>
+				<?php do_action( 'wpo_wcpdf_after_shipping_address', $this->get_type(), $this->order ); ?>
+				<?php if ( isset( $this->settings['display_phone'] ) ) : ?>
+					<div class="shipping-phone"><?php $this->shipping_phone(); ?></div>
+				<?php endif; ?>
+			<?php endif; ?>
+		</td>
+		<td class="order-data">
+			<table>
+				<?php do_action( 'wpo_wcpdf_before_order_data', $this->get_type(), $this->order ); ?>
+				<?php if ( isset( $this->settings['display_number'] ) ) : ?>
+					<tr class="invoice-number">
+						<th><?php $this->number_title(); ?></th>
+						<td><?php $this->number( $this->get_type() ); ?></td>
+					</tr>
+				<?php endif; ?>
+				<?php if ( isset( $this->settings['display_date'] ) ) : ?>
+					<tr class="invoice-date">
+						<th><?php $this->date_title(); ?></th>
+						<td><?php $this->date( $this->get_type() ); ?></td>
+					</tr>
+				<?php endif; ?>
+				<tr class="order-number">
+					<th><?php $this->order_number_title(); ?></th>
+					<td><?php $this->order_number(); ?></td>
+				</tr>
+				<tr class="order-date">
+					<th><?php $this->order_date_title(); ?></th>
+					<td><?php $this->order_date(); ?></td>
+				</tr>
+				<?php if ( $this->get_payment_method() ) : ?>
+					<tr class="payment-method">
+						<th><?php $this->payment_method_title(); ?></th>
+						<td><?php $this->payment_method(); ?></td>
+					</tr>
+				<?php endif; ?>
+				<?php do_action( 'wpo_wcpdf_after_order_data', $this->get_type(), $this->order ); ?>
+			</table>
+		</td>
+	</tr>
+</table>
+
+<?php do_action( 'wpo_wcpdf_before_order_details', $this->get_type(), $this->order ); ?>
+
+<table class="order-details">
+	<thead>
+		<tr>
+			<?php foreach ( wpo_wcpdf_get_simple_template_default_table_headers( $this ) as $column_class => $column_title ) : ?>
+				<th class="<?php echo esc_attr( $column_class ); ?>"><?php echo esc_html( $column_title ); ?></th>
+			<?php endforeach; ?>
+		</tr>
+	</thead>
+	<tbody>
+		<?php foreach ( $this->get_order_items() as $item_id => $item ) : ?>
+			<tr class="<?php echo esc_html( $item['row_class'] ); ?>">
+				<td class="product">
+					<p class="item-name"><?php echo esc_html( $item['name'] ); ?></p>
+					<?php do_action( 'wpo_wcpdf_before_item_meta', $this->get_type(), $item, $this->order ); ?>
+					<div class="item-meta">
+						<?php if ( ! empty( $item['sku'] ) ) : ?>
+							<p class="sku"><span class="label"><?php $this->sku_title(); ?></span> <?php echo esc_attr( $item['sku'] ); ?></p>
+						<?php endif; ?>
+						<?php if ( ! empty( $item['weight'] ) ) : ?>
+							<p class="weight"><span class="label"><?php $this->weight_title(); ?></span> <?php echo esc_attr( $item['weight'] ); ?><?php echo esc_attr( get_option( 'woocommerce_weight_unit' ) ); ?></p>
+						<?php endif; ?>
+						<!-- ul.wc-item-meta -->
+						<?php if ( ! empty( $item['meta'] ) ) : ?>
+							<?php echo wp_kses_post( $item['meta'] ); ?>
+						<?php endif; ?>
+						<!-- / ul.wc-item-meta -->
+					</div>
+					<?php do_action( 'wpo_wcpdf_after_item_meta', $this->get_type(), $item, $this->order ); ?>
+				</td>
+				<td class="quantity"><?php echo esc_html( $item['quantity'] ); ?></td>
+				<td class="price"><?php echo esc_html( $item['order_price'] ); ?></td>
+			</tr>
+		<?php endforeach; ?>
+	</tbody>
+</table>
+
+<table class="notes-totals">
+	<tbody>
+		<tr class="no-borders">
+			<td class="no-borders notes-cell">
+				<?php do_action( 'wpo_wcpdf_before_document_notes', $this->get_type(), $this->order ); ?>
+				<?php if ( $this->get_document_notes() ) : ?>
+					<div class="document-notes">
+						<h3><?php $this->notes_title(); ?></h3>
+						<?php $this->document_notes(); ?>
+					</div>
+				<?php endif; ?>
+				<?php do_action( 'wpo_wcpdf_after_document_notes', $this->get_type(), $this->order ); ?>
+				<?php do_action( 'wpo_wcpdf_before_customer_notes', $this->get_type(), $this->order ); ?>
+				<?php if ( $this->get_shipping_notes() ) : ?>
+					<div class="customer-notes">
+						<h3><?php $this->customer_notes_title(); ?></h3>
+						<?php $this->shipping_notes(); ?>
+					</div>
+				<?php endif; ?>
+				<?php do_action( 'wpo_wcpdf_after_customer_notes', $this->get_type(), $this->order ); ?>
+			</td>
+			<td class="no-borders totals-cell">
+				<table class="totals">
+					<tfoot>
+						<?php foreach ( $this->get_woocommerce_totals() as $key => $total ) : ?>
+							<tr class="<?php echo esc_attr( $key ); ?>">
+								<th class="description"><?php echo esc_html( $total['label'] ); ?></th>
+								<td class="price"><span class="totals-price"><?php echo esc_html( $total['value'] ); ?></span></td>
+							</tr>
+						<?php endforeach; ?>
+					</tfoot>
+				</table>
+			</td>
+		</tr>
+	</tbody>
+</table>
+
+<p class="payment-confirmation"><?php esc_html_e( 'All Payments Completed', 'woocommerce-pdf-invoices-packing-slips' ); ?></p>
+
+<?php do_action( 'wpo_wcpdf_after_order_details', $this->get_type(), $this->order ); ?>
+
+<div class="bottom-spacer"></div>
+
+<?php if ( $this->get_footer() ) : ?>
+	<htmlpagefooter name="docFooter"><!-- required for mPDF engine -->
+		<div id="footer">
+			<!-- hook available: wpo_wcpdf_before_footer -->
+			<?php $this->footer(); ?>
+			<!-- hook available: wpo_wcpdf_after_footer -->
+		</div>
+	</htmlpagefooter><!-- required for mPDF engine -->
+<?php endif; ?>
+
+<?php do_action( 'wpo_wcpdf_after_document', $this->get_type(), $this->order ); ?>

--- a/wpo-ips-functions.php
+++ b/wpo-ips-functions.php
@@ -118,7 +118,26 @@ function wcpdf_get_invoice( $order, $init = false ) {
 }
 
 function wcpdf_get_packing_slip( $order, $init = false ) {
-	return wcpdf_get_document( 'packing-slip', $order, $init );
+        return wcpdf_get_document( 'packing-slip', $order, $init );
+}
+
+function wcpdf_get_paid_invoice( $order, $init = false ) {
+        return wcpdf_get_document( 'paid-invoice', $order, $init );
+}
+
+function wcpdf_get_order_due_amount( $order ) {
+        $meta_keys = array( '_due_amount', '_wc_deposits_remaining', '_wcdp_remaining_balance' );
+        foreach ( $meta_keys as $key ) {
+                $value = get_post_meta( $order->get_id(), $key, true );
+                if ( '' !== $value ) {
+                        return floatval( $value );
+                }
+        }
+        return 0.0;
+}
+
+function wcpdf_order_fully_paid( $order ) {
+        return abs( wcpdf_get_order_due_amount( $order ) ) < 0.01;
 }
 
 function wcpdf_get_bulk_actions() {


### PR DESCRIPTION
## Summary
- add new PaidInvoice document for fully paid orders
- register PaidInvoice document
- expose helper functions for order due amount and payment check
- conditionally show PDF Invoice All Payments Completed button in admin and my account pages
- add template for paid invoice with completion notice

## Testing
- `true`

------
https://chatgpt.com/codex/tasks/task_e_68661eecac808321af1ab295802db7a2